### PR TITLE
Fixing the Delta struct

### DIFF
--- a/users/delta/delta.go
+++ b/users/delta/delta.go
@@ -2,12 +2,19 @@ package delta
 
 import (
     i04eb5309aeaafadd28374d79c8471df9b267510b4dc2e3144c378c50f6fd7b55 "github.com/microsoft/kiota/abstractions/go/serialization"
+    i4a838ef194e4c99e9f2c63ba10dab9cb120a89367c1d4ab0daa63bb424e20d87 "github.com/microsoftgraph/msgraph-sdk-go/models/microsoft/graph"
 )
 
 // Delta 
 type Delta struct {
     // Stores additional data not described in the OpenAPI description found when deserializing. Can be used for serialization as well.
     additionalData map[string]interface{};
+    //
+	nextLink *string;
+	//
+	deltaLink *string;
+	//
+	value []i4a838ef194e4c99e9f2c63ba10dab9cb120a89367c1d4ab0daa63bb424e20d87.User;
 }
 // NewDelta instantiates a new delta and sets the default values.
 func NewDelta()(*Delta) {


### PR DESCRIPTION
## Overview

The `Delta` struct is missing some parts that are being received as part of the response.
I matched it with `UsersResponse` and added `deltaLink`.

### Demo

N/A

### Notes

I'm not sure if `deltaLink` is correct. I based it on the documentation in https://docs.microsoft.com/en-us/graph/delta-query-overview.

## Testing Instructions

1. Send the request with the SDK (`graphClient.Users().Delta()().Get(options)`).
2. You'll see the failure in `github.com/microsoft/kiota/serialization/go/json@v0.0.0-20211214082231-caf19efef7a9/json_parse_node.go:192`
