### PR TITLE
- disables unit tests in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Build SDK project
         run: go build
         working-directory: ${{ env.relativePath }}
-      - name: Run unit tests
-        run: go test
-        working-directory: ${{ env.relativePath }}
+#      - name: Run unit tests
+#        run: go test
+#        working-directory: ${{ env.relativePath }}


### PR DESCRIPTION
the service library doesn't have any unit test because we're doing that at the core library, generator and raptor levels. However because the build result is not cached, and our module is large, we end up paying build time twice for no reason. Commented out in case we want to introduce some smoke test later on