### PR TITLE
Better error handling example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ func printOdataError(err error) {
 	}
 }
 
-...
+// omitted for brevity
 
 result, err := client.Me().Drive().Get()
 if err != nil {

--- a/README.md
+++ b/README.md
@@ -85,8 +85,6 @@ import (
     "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
 
-// omitted for brevity
-
 result, err := client.Me().Drive().Get()
 if err != nil {
     fmt.Printf("Error getting the drive: %v\n", err)
@@ -100,13 +98,13 @@ func printOdataError(err error) {
 	switch err.(type) {
 	case *odataerrors.ODataError:
 		typed := err.(*odataerrors.ODataError)
-		log.Println("error:", typed.Error())
+		fmt.Printf("error:", typed.Error())
 		if terr := typed.GetError(); terr != nil {
-			log.Printf("code: %s", *terr.GetCode())
-			log.Printf("msg: %s", *terr.GetMessage())
+			fmt.Printf("code: %s", *terr.GetCode())
+			fmt.Printf("msg: %s", *terr.GetMessage())
 		}
 	default:
-		log.Printf("%T > error: %#v", err, err)
+		fmt.Printf("%T > error: %#v", err, err)
 	}
 }
 
@@ -127,8 +125,6 @@ import (
     "github.com/microsoftgraph/msgraph-sdk-go/models"
     "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
-
-// omitted for brevity
 
 result, err := client.Users().Get(nil)
 if err != nil {
@@ -153,13 +149,13 @@ func printOdataError(err error) {
         switch err.(type) {
         case *odataerrors.ODataError:
                 typed := err.(*odataerrors.ODataError)
-                log.Println("error:", typed.Error())
+                fmt.Printf("error:", typed.Error())
                 if terr := typed.GetError(); terr != nil {
-                        log.Printf("code: %s", *terr.GetCode())
-                        log.Printf("msg: %s", *terr.GetMessage())
+                        fmt.Printf("code: %s", *terr.GetCode())
+                        fmt.Printf("msg: %s", *terr.GetMessage())
                 }
         default:
-                log.Printf("%T > error: %#v", err, err)
+                fmt.Printf("%T > error: %#v", err, err)
         }
 }
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,30 @@ After you have a **GraphServiceClient** that is authenticated, you can begin mak
 To retrieve the user's drive:
 
 ```Golang
+import (
+    "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
+)
+
+func printOdataError(err error) {
+	switch err.(type) {
+	case *odataerrors.ODataError:
+		typed := err.(*odataerrors.ODataError)
+		log.Println("error:", typed.Error())
+		if terr := typed.GetError(); terr != nil {
+			log.Printf("code: %s", *terr.GetCode())
+			log.Printf("msg: %s", *terr.GetMessage())
+		}
+	default:
+		log.Printf("%T > error: %#v", err, err)
+	}
+}
+
+...
+
 result, err := client.Me().Drive().Get()
 if err != nil {
     fmt.Printf("Error getting the drive: %v\n", err)
+    printOdataError(err)
 }
 fmt.Printf("Found Drive : %v\n", *result.GetId())
 ```
@@ -101,11 +122,29 @@ import (
     msgraphcore "github.com/microsoftgraph/msgraph-sdk-go-core"
     "github.com/microsoftgraph/msgraph-sdk-go/users"
     "github.com/microsoftgraph/msgraph-sdk-go/models"
+    "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
+
+func printOdataError(err error) {
+        switch err.(type) {
+        case *odataerrors.ODataError:
+                typed := err.(*odataerrors.ODataError)
+                log.Println("error:", typed.Error())
+                if terr := typed.GetError(); terr != nil {
+                        log.Printf("code: %s", *terr.GetCode())
+                        log.Printf("msg: %s", *terr.GetMessage())
+                }
+        default:
+                log.Printf("%T > error: %#v", err, err)
+        }
+}
+
+...
 
 result, err := client.Users().Get(nil)
 if err != nil {
     fmt.Printf("Error getting users: %v\n", err)
+    printOdataError(err error)
     return err
 }
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ import (
     "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
 
+// omitted for brevity
+
+result, err := client.Me().Drive().Get()
+if err != nil {
+    fmt.Printf("Error getting the drive: %v\n", err)
+    printOdataError(err)
+}
+fmt.Printf("Found Drive : %v\n", *result.GetId())
+
+// omitted for brevity
+
 func printOdataError(err error) {
 	switch err.(type) {
 	case *odataerrors.ODataError:
@@ -99,14 +110,6 @@ func printOdataError(err error) {
 	}
 }
 
-// omitted for brevity
-
-result, err := client.Me().Drive().Get()
-if err != nil {
-    fmt.Printf("Error getting the drive: %v\n", err)
-    printOdataError(err)
-}
-fmt.Printf("Found Drive : %v\n", *result.GetId())
 ```
 
 ## 4. Getting results that span across multiple pages
@@ -125,21 +128,7 @@ import (
     "github.com/microsoftgraph/msgraph-sdk-go/models/odataerrors"
 )
 
-func printOdataError(err error) {
-        switch err.(type) {
-        case *odataerrors.ODataError:
-                typed := err.(*odataerrors.ODataError)
-                log.Println("error:", typed.Error())
-                if terr := typed.GetError(); terr != nil {
-                        log.Printf("code: %s", *terr.GetCode())
-                        log.Printf("msg: %s", *terr.GetMessage())
-                }
-        default:
-                log.Printf("%T > error: %#v", err, err)
-        }
-}
-
-...
+// omitted for brevity
 
 result, err := client.Users().Get(nil)
 if err != nil {
@@ -157,6 +146,23 @@ err = pageIterator.Iterate(func(pageItem interface{}) bool {
     // Return true to continue the iteration
     return true
 })
+
+// omitted for brevity
+
+func printOdataError(err error) {
+        switch err.(type) {
+        case *odataerrors.ODataError:
+                typed := err.(*odataerrors.ODataError)
+                log.Println("error:", typed.Error())
+                if terr := typed.GetError(); terr != nil {
+                        log.Printf("code: %s", *terr.GetCode())
+                        log.Printf("msg: %s", *terr.GetMessage())
+                }
+        default:
+                log.Printf("%T > error: %#v", err, err)
+        }
+}
+
 ```
 
 ## 5. Documentation


### PR DESCRIPTION
when using result, err := client.Me().Drive().Get(), and in case of error, you get an error string like "error status code received from the API" which is far from explicit.

With the printOdataError() function, you get something more meaningful, like:

```
2022/07/13 01:59:15 code: BadRequest
2022/07/13 01:59:15 msg: /me request is only valid with delegated authentication flow
```

## Overview

Brief description of what this PR does.

### Demo

Optional. Screenshots, examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output
