### PR TITLE
- switches to bigger runner to avoid memory exhaustion

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, 1ES.Pool=1es-ubuntu-github-beta-sdk-go-compute-latest]
     env:
       relativePath: ./
     steps:


### PR DESCRIPTION
This is an experiment to see if repo level runners are shared. Probably won't work and I'll need to make another runner.