### PR TITLE
ci: set include v in tag for release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
     "bump-minor-pre-major": true,
     "bump-patch-for-minor-pre-major": true,
     "include-component-in-tag": false,
+    "include-v-in-tag": true,
     "packages": {
         ".": {
           "package-name": "github.com/microsoftgraph/msgraph-sdk-go",


### PR DESCRIPTION
Fixes regression https://github.com/microsoftgraph/msgraph-sdk-go/issues/714.

Adds `include-v-in-tag` in release please config