### PR TITLE
Recall release version 1.44 and 1.45

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,3 +31,10 @@ require (
 	golang.org/x/text v0.16.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract (
+	v1.44.0
+	// release contains a unintentined breaking change in name of classes
+	v1.45.0
+	// release contains a unintentined breaking change in name of classes
+)


### PR DESCRIPTION
Recall versions 1.44 and 1.45
Depends on  https://github.com/microsoft/kiota/pull/4817
