### PR TITLE
adding setter and getter of contentBytes to attachment objects.

### DIFF
--- a/models/attachment.go
+++ b/models/attachment.go
@@ -1,8 +1,8 @@
 package models
 
 import (
-    i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e "time"
     i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91 "github.com/microsoft/kiota-abstractions-go/serialization"
+    i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e "time"
 )
 
 type Attachment struct {
@@ -54,6 +54,19 @@ func (m *Attachment) GetContentType()(*string) {
     }
     return nil
 }
+
+// GetContentBytes gets the contentBytes property value. The content of the attachment in bytes.
+func (m *Attachment) GetContentBytes() *[]byte {
+    val, err := m.GetBackingStore().Get("contentBytes")
+    if err != nil {
+        panic(err)
+    }
+    if val != nil {
+        return val.(*[]byte)
+    }
+    return nil
+}
+
 // GetFieldDeserializers the deserialization information for the current model
 // returns a map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error) when successful
 func (m *Attachment) GetFieldDeserializers()(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error)) {
@@ -203,6 +216,13 @@ func (m *Attachment) SetContentType(value *string)() {
         panic(err)
     }
 }
+// SetContentBytes sets the contentBytes property value. The content of the attachment in bytes.
+func (m *Attachment) SetContentBytes(value *[]byte)() {
+    err := m.GetBackingStore().Set("contentBytes", value)
+    if err != nil {
+        panic(err)
+    }
+}
 // SetIsInline sets the isInline property value. true if the attachment is an inline attachment; otherwise, false.
 func (m *Attachment) SetIsInline(value *bool)() {
     err := m.GetBackingStore().Set("isInline", value)
@@ -235,11 +255,13 @@ type Attachmentable interface {
     Entityable
     i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable
     GetContentType()(*string)
+	GetContentBytes() *[]byte
     GetIsInline()(*bool)
     GetLastModifiedDateTime()(*i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time)
     GetName()(*string)
     GetSize()(*int32)
     SetContentType(value *string)()
+	SetContentBytes(value *[]byte)()
     SetIsInline(value *bool)()
     SetLastModifiedDateTime(value *i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time)()
     SetName(value *string)()

--- a/models/attachment_base.go
+++ b/models/attachment_base.go
@@ -1,8 +1,8 @@
 package models
 
 import (
-    i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e "time"
     i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91 "github.com/microsoft/kiota-abstractions-go/serialization"
+    i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e "time"
 )
 
 type AttachmentBase struct {
@@ -47,6 +47,17 @@ func (m *AttachmentBase) GetContentType()(*string) {
     }
     if val != nil {
         return val.(*string)
+    }
+    return nil
+}
+// GetContentBytes gets the contentBytes property value. The content of the attachment in bytes.
+func (m *AttachmentBase) GetContentBytes() *[]byte {
+    val, err := m.GetBackingStore().Get("contentBytes")
+    if err != nil {
+        panic(err)
+    }
+    if val != nil {
+        return val.(*[]byte)
     }
     return nil
 }
@@ -171,6 +182,13 @@ func (m *AttachmentBase) SetContentType(value *string)() {
         panic(err)
     }
 }
+// SetContentBytes sets the contentBytes property value. The content of the attachment in bytes.
+func (m *AttachmentBase) SetContentBytes(value *[]byte)() {
+    err := m.GetBackingStore().Set("contentBytes", value)
+    if err != nil {
+        panic(err)
+    }
+}
 // SetLastModifiedDateTime sets the lastModifiedDateTime property value. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 is 2014-01-01T00:00:00Z.
 func (m *AttachmentBase) SetLastModifiedDateTime(value *i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time)() {
     err := m.GetBackingStore().Set("lastModifiedDateTime", value)
@@ -196,10 +214,12 @@ type AttachmentBaseable interface {
     Entityable
     i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.Parsable
     GetContentType()(*string)
+    GetContentBytes() *[]byte
     GetLastModifiedDateTime()(*i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time)
     GetName()(*string)
     GetSize()(*int32)
     SetContentType(value *string)()
+    SetContentBytes(value *[]byte)()
     SetLastModifiedDateTime(value *i336074805fc853987abe6f7fe3ad97a6a6f3077a16391fec744f671a015fbd7e.Time)()
     SetName(value *string)()
     SetSize(value *int32)()

--- a/models/attachment_info.go
+++ b/models/attachment_info.go
@@ -64,6 +64,17 @@ func (m *AttachmentInfo) GetContentType()(*string) {
     }
     return nil
 }
+// GetContentBytes gets the contentBytes property value. The content of the attachment in bytes.
+func (m *AttachmentInfo) GetContentBytes() *[]byte {
+    val, err := m.GetBackingStore().Get("contentBytes")
+    if err != nil {
+        panic(err)
+    }
+    if val != nil {
+        return val.(*[]byte)
+    }
+    return nil
+}
 // GetFieldDeserializers the deserialization information for the current model
 // returns a map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error) when successful
 func (m *AttachmentInfo) GetFieldDeserializers()(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error)) {
@@ -222,6 +233,13 @@ func (m *AttachmentInfo) SetContentType(value *string)() {
         panic(err)
     }
 }
+// SetContentBytes sets the contentBytes property value. The content of the attachment in bytes.
+func (m *AttachmentInfo) SetContentBytes(value *[]byte)() {
+    err := m.GetBackingStore().Set("contentBytes", value)
+    if err != nil {
+        panic(err)
+    }
+}
 // SetName sets the name property value. The display name of the attachment. This can be a descriptive string and doesn't have to be the actual file name. Required.
 func (m *AttachmentInfo) SetName(value *string)() {
     err := m.GetBackingStore().Set("name", value)
@@ -250,12 +268,14 @@ type AttachmentInfoable interface {
     GetAttachmentType()(*AttachmentType)
     GetBackingStore()(ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore)
     GetContentType()(*string)
+    GetContentBytes() *[]byte
     GetName()(*string)
     GetOdataType()(*string)
     GetSize()(*int64)
     SetAttachmentType(value *AttachmentType)()
     SetBackingStore(value ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore)()
     SetContentType(value *string)()
+    SetContentBytes(value *[]byte)()
     SetName(value *string)()
     SetOdataType(value *string)()
     SetSize(value *int64)()

--- a/models/attachment_item.go
+++ b/models/attachment_item.go
@@ -76,6 +76,17 @@ func (m *AttachmentItem) GetContentType()(*string) {
     }
     return nil
 }
+// GetContentBytes gets the contentBytes property value. The content of the attachment in bytes.
+func (m *AttachmentItem) GetContentBytes() *[]byte {
+    val, err := m.GetBackingStore().Get("contentBytes")
+    if err != nil {
+        panic(err)
+    }
+    if val != nil {
+        return val.(*[]byte)
+    }
+    return nil
+}
 // GetFieldDeserializers the deserialization information for the current model
 // returns a map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error) when successful
 func (m *AttachmentItem) GetFieldDeserializers()(map[string]func(i878a80d2330e89d26896388a3f487eef27b0a0e6c010c493bf80be1452208f91.ParseNode)(error)) {
@@ -285,6 +296,13 @@ func (m *AttachmentItem) SetContentType(value *string)() {
         panic(err)
     }
 }
+// SetContentBytes sets the contentBytes property value. The content of the attachment in bytes.
+func (m *AttachmentItem) SetContentBytes(value *[]byte)() {
+    err := m.GetBackingStore().Set("contentBytes", value)
+    if err != nil {
+        panic(err)
+    }
+}
 // SetIsInline sets the isInline property value. true if the attachment is an inline attachment; otherwise, false. Optional.
 func (m *AttachmentItem) SetIsInline(value *bool)() {
     err := m.GetBackingStore().Set("isInline", value)
@@ -321,6 +339,7 @@ type AttachmentItemable interface {
     GetBackingStore()(ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore)
     GetContentId()(*string)
     GetContentType()(*string)
+    GetContentBytes() *[]byte
     GetIsInline()(*bool)
     GetName()(*string)
     GetOdataType()(*string)
@@ -329,6 +348,7 @@ type AttachmentItemable interface {
     SetBackingStore(value ie8677ce2c7e1b4c22e9c3827ecd078d41185424dd9eeb92b7d971ed2d49a392e.BackingStore)()
     SetContentId(value *string)()
     SetContentType(value *string)()
+    SetContentBytes(value *[]byte)()
     SetIsInline(value *bool)()
     SetName(value *string)()
     SetOdataType(value *string)()


### PR DESCRIPTION
## Overview

This PR adds a Setter and Geter for ContentBytes in attachment objects. This enhancement aligns the SDK with the official Microsoft Graph API documentation, enabling more seamless interaction with attachment content bytes. The relevant documentation can be found [here](https://learn.microsoft.com/en-us/graph/api/message-list-attachments?view=graph-rest-1.0&tabs=go#response-1).

### Demo

```
// Create a new attachment object
attachment := msgraph.NewAttachment()
// Set ContentBytes
attachment.SetContentBytes([]byte("Your content bytes here"))
// Get ContentBytes
contentBytes := attachment.GetContentBytes()
```

### Notes

This implementation follows the pattern established in the existing codebase, ensuring compatibility and ease of integration. An alternative approach was considered but discarded due to complexity and potential compatibility issues.

## Testing Instructions

The geter should return the exact byte slice that is in the attachment, and can be stored in the pure file, like:
```
contentBytes := attachment.GetContentBytes()
if contentBytes != nil {
        file, err := os.OpenFile(path, attachment.Name, os.O_CREATE|os.O_WRONLY, 0755)
        if err == nil {
	        _, err := file.Write(*contentBytes)
	        if err != nil {
		        log.Panic(err)
	        }
	        file.Close()
        } else {
	        log.Panic(err)
        }
}
```