### PR TITLE
Change missing method GetError to GetErrorEscaped in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ func printOdataError(err error) {
         case *odataerrors.ODataError:
                 typed := err.(*odataerrors.ODataError)
                 fmt.Printf("error: %s", typed.Error())
-                if terr := typed.GetError(); terr != nil {
+                if terr := typed.GetErrorEscaped(); terr != nil {
                         fmt.Printf("code: %s", *terr.GetCode())
                         fmt.Printf("msg: %s", *terr.GetMessage())
                 }

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ func printOdataError(err error) {
 	case *odataerrors.ODataError:
 		typed := err.(*odataerrors.ODataError)
 		fmt.Printf("error:", typed.Error())
-		if terr := typed.GetError(); terr != nil {
+		if terr := typed.GetErrorEscaped(); terr != nil {
 			fmt.Printf("code: %s", *terr.GetCode())
 			fmt.Printf("msg: %s", *terr.GetMessage())
 		}


### PR DESCRIPTION
## Overview

Update the README docs with `ODataError` change which changed the method name from `GetError()` to `GetErrorEscaped()`

fixes https://github.com/microsoftgraph/msgraph-sdk-go/issues/690
