### PR TITLE
fix: add missing image and enable Go module proxy in daily CI build

### DIFF
--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -21,6 +21,7 @@ extends:
   parameters:
     pool:
       name: Azure-Pipelines-1ESPT-ExDShared
+      image: ubuntu-latest
       os: linux
     sdl:
       sourceAnalysisPool:

--- a/.azure-pipelines/daily-ci-build.yml
+++ b/.azure-pipelines/daily-ci-build.yml
@@ -23,6 +23,10 @@ extends:
       name: Azure-Pipelines-1ESPT-ExDShared
       image: ubuntu-latest
       os: linux
+    featureFlags:
+      golang:
+        internalModuleProxy:
+          enabled: true
     sdl:
       sourceAnalysisPool:
         name: Azure-Pipelines-1ESPT-ExDShared


### PR DESCRIPTION
## Changes

- Added missing `image: ubuntu-latest` property to the main pool configuration (required by 1ES Pipeline Templates)
- Enabled `featureFlags.golang.internalModuleProxy.enabled: true` to opt in to Microsoft's internal Go module proxy (required for all 1ES Go builds after August 2025, see aka.ms/goproxy)

## Errors Fixed
1. `1ES PT Error: The os property specified in the pool does not match with the actual image`
2. `After_August_2025_new_golang_builds_must_pull_public_modules_from_the_internal_public_module_proxy`